### PR TITLE
chore: bump version to 0.7.0 and update keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anysiteio/mcp",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "A comprehensive MCP server with 57 tools for LinkedIn, Instagram, Twitter/X, Reddit, and web scraping via AnySite API",
   "private": false,
   "type": "module",
@@ -37,7 +37,12 @@
     "claude",
     "linkedin",
     "instagram",
-    "anysite"
+    "twitter",
+    "reddit",
+    "web-scraping",
+    "anysite",
+    "ai-agent",
+    "model-context-protocol"
   ],
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Version bump from 0.6.3 to 0.7.0 for new feature release.

Changes:
- Bump version to 0.7.0 (minor version for 28 new tools)
- Add new keywords: twitter, reddit, web-scraping, ai-agent, model-context-protocol
- Reflects expanded platform support and new capabilities

This version includes:
- 57 total tools (was 29)
- Twitter/X support (5 new tools)
- Enhanced Instagram support (8 tools total, was 3)
- Web Parser capabilities (2 new tools)
- LinkedIn enhancements (26 tools total, was 22)
- ChatGPT Deep Research tools (2 optional tools)
